### PR TITLE
chore(Obsidian-santizer): ensure gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ __pycache__
 .venv/
 .vscode
 .DS_Store
+# Managed by gix gitignore workflow
+.env
+.env.*
+qodana.yaml
+.idea/
+tools/
+bin/


### PR DESCRIPTION
Ensure `.gitignore` contains the standard secrets/tooling entries (.env, tools/, bin/).